### PR TITLE
Fixed the 'omxplayer -s' stats regex to use the time from the audio, …

### DIFF
--- a/pyomxplayer/__init__.py
+++ b/pyomxplayer/__init__.py
@@ -8,7 +8,7 @@ from pyomxplayer.parser import OMXPlayerParser
 
 
 class OMXPlayer(object):
-    _STATUS_REGEX = re.compile(r'V :\s*([\d.]+).*')
+    _STATUS_REGEX = re.compile(r'A:\s*[\d.]+\s-?([\d.]+).*')
     _DONE_REGEX = re.compile(r'have a nice day.*')
 
     _LAUNCH_CMD = 'omxplayer -s %s %s'
@@ -25,6 +25,8 @@ class OMXPlayer(object):
         self._launch_omxplayer(media_file, args)
         self.parser = _parser(self._process)
         self._monitor_play_position()
+
+        self.position = 0.0
 
         # By default the process starts playing
         self.paused = False


### PR DESCRIPTION
…seems the best method to get rough seconds elapsed.  Also set initial position to 0 to prevent position not being a property on self if checked too soon externally.

This works for:

> $ omxplayer --version
> omxplayer - Commandline multimedia player for the Raspberry Pi
>         Build date: Fri, 06 May 2016 14:07:54 +0000
>         Version   : 6c90c75 [master]
>         Repository: https://github.com/popcornmix/omxplayer.git
